### PR TITLE
Remove learnusd.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Scene and other assets put together to test USD features and as examples of how 
 - [USD at Remedy Entertainment](https://www.youtube.com/watch?v=FI2pyzTOvaQ) – Presentation about how Remedy Entertainment uses USD for gamedev.
 - [Essentials of USD in Omniverse](https://courses.nvidia.com/courses/course-v1:DLI+S-OV-05+V1/) – Fully web-hosted course to learn USD for developers in Omniverse.
 - [USD Survival Guide](https://lucascheller.github.io/VFX-UsdSurvivalGuide/introduction/overview.html) – An onboarding guide for software engineers and pipeline TDs with practical and production examples.
-- [LearnUSD Guide](https://learnusd.github.io/) - A from-the-ground-up introduction to OpenUSD through Omniverse Python runnable examples.
 
 ## References
 


### PR DESCRIPTION
The website is no longer available

The group it was in is also empty with the repo gone: https://github.com/learnusd

Bit of a shame as it looks like it could have been interesting.